### PR TITLE
bump mach-glfw hash

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,7 +14,7 @@
     .dependencies = .{
         .mach_glfw = .{
             .url = "https://pkg.machengine.org/mach-glfw/20d247fa4b70c0b3951cb3c439d3466f204754e1.tar.gz",
-            .hash = "1220533928f944fe59f6dd2807db71cd69108cc810101e627835c3abcc4afea4fb06",
+            .hash = "1220f237ad1e96b317837c766d9d2e92fb0a2b311cc9645877b520bd59ddc7cc55ee",
         },
         .mach_gpu_dawn = .{
             .url = "https://pkg.machengine.org/mach-gpu-dawn/16b234c1aae36469b71b640bcfbe4967f1086260.tar.gz",


### PR DESCRIPTION
My mach-gpu build is currently failing because of this transitive dependency failure:

```
$ zig build
Fetch Packages [2/3] mach_gpu.mach_glfw... /Users/jake/.cache/zig/p/12203ffbe080e62a989e37f462d709ae5d5b9d338339da547de2e6f1811eb3c9afab/build.zig.zon:17:21: error: hash mismatch: expected: 1220533928f944fe59f6dd2807db71cd69108cc810101e627835c3abcc4afea4fb06, found: 1220f237ad1e96b317837c766d9d2e92fb0a2b311cc9645877b520bd59ddc7cc55ee
            .hash = "1220533928f944fe59f6dd2807db71cd69108cc810101e627835c3abcc4afea4fb06",
```



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.