### PR TITLE
Fix return type mismatch in device and adapter

### DIFF
--- a/src/adapter.zig
+++ b/src/adapter.zig
@@ -72,7 +72,7 @@ pub const Adapter = opaque {
     }
 
     pub inline fn getLimits(adapter: *Adapter, limits: *SupportedLimits) bool {
-        return Impl.adapterGetLimits(adapter, limits);
+        return Impl.adapterGetLimits(adapter, limits) != 0;
     }
 
     pub inline fn getProperties(adapter: *Adapter, properties: *Adapter.Properties) void {
@@ -80,7 +80,7 @@ pub const Adapter = opaque {
     }
 
     pub inline fn hasFeature(adapter: *Adapter, feature: FeatureName) bool {
-        return Impl.adapterHasFeature(adapter, feature);
+        return Impl.adapterHasFeature(adapter, feature) != 0;
     }
 
     pub inline fn requestDevice(

--- a/src/device.zig
+++ b/src/device.zig
@@ -248,7 +248,7 @@ pub const Device = opaque {
     }
 
     pub inline fn getLimits(device: *Device, limits: *SupportedLimits) bool {
-        return Impl.deviceGetLimits(device, limits);
+        return Impl.deviceGetLimits(device, limits) != 0;
     }
 
     pub inline fn getQueue(device: *Device) *Queue {
@@ -256,7 +256,7 @@ pub const Device = opaque {
     }
 
     pub inline fn hasFeature(device: *Device, feature: FeatureName) bool {
-        return Impl.deviceHasFeature(device, feature);
+        return Impl.deviceHasFeature(device, feature) != 0;
     }
 
     pub inline fn injectError(device: *Device, typ: ErrorType, message: [*:0]const u8) void {


### PR DESCRIPTION
A few of the wgpu bindings return a u32 for a bool, but the mach api that wraps these functions returns a zig `bool`. This commit fixes the type mismatch so that these functions will compile.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.